### PR TITLE
Added some sensible defaults to git-pr_csdiff

### DIFF
--- a/bin/git-pr_csdiff
+++ b/bin/git-pr_csdiff
@@ -91,7 +91,10 @@ for (;@ARGV;) {
 # Validate command-line options #
 #################################
 
-&Usage if @ARGV == 0 || $ARGV[-1] =~ /^-/;
+# Some sensible defaults
+unshift(@ARGV, "-C5") unless grep(/^-C/, @ARGV);
+push(@ARGV, ".") if @ARGV == 0 || $ARGV[-1] =~ /^-/;
+
 &Usage if @REVLIST > 2;
 my $FILE=pop(@ARGV);
 


### PR DESCRIPTION
`git-pr_csdiff` will now default to using options `-C5` for context and `.` for the path. This brings default usage closer to the standard `git diff`.
